### PR TITLE
feat: Move Google login to backend flow

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,16 +1,88 @@
 # app/api/auth.py
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Request
+from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.database import get_db
 from app.schemas.user import UserCreate, LoginResponse, UserRegistration, UserResponse
 from app.services.user_service import UserService
-from app.core.auth import create_access_token, verify_google_token, get_current_user_id
+from app.core.auth import (
+    create_access_token,
+    verify_google_token,
+    get_current_user_id,
+    get_google_auth_url,
+    exchange_code_for_tokens
+)
 from datetime import timedelta
+import os
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
-@router.post("/login", response_model=LoginResponse)
-async def login_with_google(
+@router.get("/google/login")
+async def google_login():
+    """
+    Redirects to Google's OAuth 2.0 consent screen.
+    """
+    return RedirectResponse(url=get_google_auth_url())
+
+@router.get("/google/callback")
+async def google_callback(
+    request: Request,
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    Handles the callback from Google after user authentication.
+    """
+    try:
+        code = request.query_params.get('code')
+        if not code:
+            raise HTTPException(status_code=400, detail="Authorization code not found in callback.")
+
+        token_data = exchange_code_for_tokens(code)
+
+        user_info = token_data['user_info']
+        google_id = user_info['sub']
+        email = user_info['email']
+
+        user_service = UserService(db)
+        user = await user_service.get_user_by_google_id(google_id)
+
+        if user:
+            user = await user_service.update_user_tokens(
+                user=user,
+                access_token=token_data['access_token'],
+                refresh_token=token_data['refresh_token']
+            )
+        else:
+            user = await user_service.create_user(
+                email=email,
+                google_id=google_id,
+                access_token=token_data['access_token'],
+                refresh_token=token_data['refresh_token']
+            )
+
+        # Create JWT token for frontend
+        access_token_expires = timedelta(minutes=30)
+        jwt_token = create_access_token(
+            data={"sub": str(user.id)}, expires_delta=access_token_expires
+        )
+
+        # Redirect to frontend with the token
+        frontend_url = os.getenv("FRONTEND_URL", "http://localhost:5173")
+        redirect_url = f"{frontend_url}/auth/callback?token={jwt_token}"
+
+        return RedirectResponse(url=redirect_url)
+
+    except HTTPException as e:
+        # Re-raise HTTP exceptions
+        raise e
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Authentication failed: {str(e)}"
+        )
+
+@router.post("/login_with_token", response_model=LoginResponse, deprecated=True)
+async def login_with_google_token(
     user_data: UserCreate,
     db: AsyncSession = Depends(get_db)
 ):
@@ -29,21 +101,14 @@ async def login_with_google(
         # Check if user exists
         user = await user_service.get_user_by_google_id(google_id)
         
-        if user:
-            # If user exists and new tokens are provided, update them
-            if user_data.google_access_token:
-                user = await user_service.update_user_tokens(
-                    user=user,
-                    access_token=user_data.google_access_token,
-                    refresh_token=user_data.google_refresh_token
-                )
-        else:
-            # Create new user
+        if not user:
+            # Create new user if they don't exist
+            # Note: access_token and refresh_token are not provided in this flow
             user = await user_service.create_user(
                 email=email,
                 google_id=google_id,
-                access_token=user_data.google_access_token,
-                refresh_token=user_data.google_refresh_token
+                access_token=None,
+                refresh_token=None
             )
         
         # Create JWT token

--- a/backend/app/services/google_calendar_service.py
+++ b/backend/app/services/google_calendar_service.py
@@ -1,0 +1,63 @@
+# app/services/google_calendar_service.py
+import os
+from typing import List, Dict, Any, Optional
+from google.oauth2.credentials import Credentials
+from google.auth.transport.requests import Request
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from app.db.models.user import User
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.services.user_service import UserService
+
+GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
+GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
+
+class GoogleCalendarService:
+    def __init__(self, user: User, db: AsyncSession):
+        self.user = user
+        self.db = db
+        self.creds = self._get_credentials()
+
+    def _get_credentials(self) -> Optional[Credentials]:
+        """Create Google credentials from user data."""
+        if not self.user.google_access_token:
+            return None
+
+        # The scopes here should be a subset of what was granted during OAuth
+        return Credentials(
+            token=self.user.google_access_token,
+            refresh_token=self.user.google_refresh_token,
+            token_uri="https://oauth2.googleapis.com/token",
+            client_id=GOOGLE_CLIENT_ID,
+            client_secret=GOOGLE_CLIENT_SECRET,
+            scopes=["https://www.googleapis.com/auth/calendar"]
+        )
+
+    async def _refresh_credentials_if_needed(self):
+        """Refresh token if expired and update user."""
+        if self.creds and self.creds.expired and self.creds.refresh_token:
+            self.creds.refresh(Request())
+            user_service = UserService(self.db)
+            await user_service.update_user_tokens(
+                user=self.user,
+                access_token=self.creds.token,
+                refresh_token=self.creds.refresh_token
+            )
+
+    def _build_service(self):
+        """Build the Google Calendar API service."""
+        return build('calendar', 'v3', credentials=self.creds)
+
+    async def list_calendars(self) -> List[Dict[str, Any]]:
+        """List all of a user's Google Calendars."""
+        if not self.creds:
+            raise ValueError("User does not have Google credentials.")
+
+        await self._refresh_credentials_if_needed()
+
+        try:
+            service = self._build_service()
+            calendar_list = service.calendarList().list().execute()
+            return calendar_list.get('items', [])
+        except HttpError as err:
+            raise Exception(f"Google Calendar API error: {err}")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,36 +1,39 @@
 // src/App.tsx
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import { GoogleOAuthProvider } from '@react-oauth/google';
 import LandingPage from "./pages/LandingPage";
 import LoginPage from "./pages/LoginPage";
 import RegistrationPage from "./pages/RegistrationPage";
 import UserDashboard from "./pages/UserDashboard";
+import AuthCallback from './pages/AuthCallback';
 import { AuthProvider } from './contexts/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
 
-// Replace with your actual Google Client ID
-const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || "your-google-client-id";
-
 export default function App() {
   return (
-    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
-      <AuthProvider>
-        <Router>
-          <Routes>
-            <Route path="/" element={<LandingPage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/register" element={<RegistrationPage />} />
-            <Route
-              path="/dashboard"
-              element={
-                <ProtectedRoute>
-                  <UserDashboard />
-                </ProtectedRoute>
-              }
-            />
-          </Routes>
-        </Router>
-      </AuthProvider>
-    </GoogleOAuthProvider>
+    <AuthProvider>
+      <Router>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/auth/callback" element={<AuthCallback />} />
+          <Route
+            path="/register"
+            element={
+              <ProtectedRoute>
+                <RegistrationPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute>
+                <UserDashboard />
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </Router>
+    </AuthProvider>
   );
 }

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -1,0 +1,43 @@
+// src/pages/AuthCallback.tsx
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+export default function AuthCallback() {
+  const { handleAuthCallback, user } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const token = searchParams.get('token');
+
+    if (token) {
+      handleAuthCallback(token);
+    } else {
+      // Handle error: no token found
+      console.error("No token found in callback URL");
+      navigate('/login');
+    }
+  }, [location, handleAuthCallback, navigate]);
+
+  useEffect(() => {
+    if (user) {
+      if (user.is_registered) {
+        navigate('/dashboard');
+      } else {
+        navigate('/register');
+      }
+    }
+  }, [user, navigate]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand mb-4"></div>
+        <h1 className="text-2xl font-bold">Authenticating...</h1>
+        <p className="text-zinc-600">Please wait while we log you in.</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,10 +1,9 @@
 // src/pages/LoginPage.tsx
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { GoogleLogin } from '@react-oauth/google';
 import { useAuth } from '../contexts/AuthContext';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, LogIn } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
@@ -25,25 +24,11 @@ export default function LoginPage() {
     }
   }, [user, navigate]);
 
-  const handleGoogleSuccess = async (credentialResponse: any) => {
-    if (credentialResponse.credential) {
-      const result = await login(credentialResponse.credential);
-      
-      if (result.success) {
-        if (result.isRegistered) {
-          navigate('/dashboard');
-        } else {
-          navigate('/register');
-        }
-      } else {
-        alert(result.error || 'Login failed. Please try again.');
-      }
-    }
-  };
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
 
-  const handleGoogleError = () => {
-    console.error('Google login failed');
-    alert('Google login failed. Please try again.');
+  const handleLoginClick = () => {
+    // Redirect to the backend login endpoint
+    window.location.href = `${API_BASE_URL}/auth/google/login`;
   };
 
   return (
@@ -71,26 +56,23 @@ export default function LoginPage() {
               </p>
             </div>
 
-            {/* Google Login Button */}
+            {/* Login Button */}
             <div className="flex justify-center">
               {isLoading ? (
-                <div className="flex items-center justify-center py-3 px-6">
+                <div className="flex items-center justify-center py-3 px-6 w-full bg-zinc-100 dark:bg-zinc-700 rounded-lg">
                   <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-brand"></div>
-                  <span className="ml-2 text-zinc-600 dark:text-zinc-400">
+                  <span className="ml-3 text-zinc-600 dark:text-zinc-400">
                     {t('auth.signing_in')}
                   </span>
                 </div>
               ) : (
-                <GoogleLogin
-                  onSuccess={handleGoogleSuccess}
-                  onError={handleGoogleError}
-                  useOneTap={false}
-                  theme="outline"
-                  size="large"
-                  text="signin_with"
-                  shape="rectangular"
-                  logo_alignment="left"
-                />
+                <button
+                  onClick={handleLoginClick}
+                  className="w-full flex items-center justify-center gap-3 bg-brand hover:bg-brand/90 text-white font-semibold py-3 px-6 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand"
+                >
+                  <LogIn size={20} />
+                  <span>{t('auth.sign_in_with_google')}</span>
+                </button>
               )}
             </div>
 


### PR DESCRIPTION
This commit refactors the Google login process from a frontend-only implementation to a backend-driven OAuth2 flow.

Changes include:
- Added new backend endpoints `/auth/google/login` and `/auth/google/callback` to handle the OAuth2 flow.
- Added scopes for Google Contacts and Google Calendar API access.
- Created a new `GoogleCalendarService` and ensured the existing `GoogleContactService` is compatible with the new flow.
- Refactored the frontend login page to use the new backend endpoints.
- Added a new frontend route `/auth/callback` to handle the post-login redirect.
- Deprecated the old frontend-driven login flow.